### PR TITLE
Make narwhal work with OpenJDK on Fedora

### DIFF
--- a/engines/rhino/bin/narwhal-rhino
+++ b/engines/rhino/bin/narwhal-rhino
@@ -24,9 +24,13 @@ BOOTCLASSPATH=$NARWHAL_ENGINE_HOME/jars/js.jar
 JAVA_OPTS=""
 isOpenJDK=`java -version 2>&1 | grep -i "OpenJDK" | wc -l`
 
-if [ $isOpenJDK -gt 0 ]; then
-    JAVA_OPTS="-Xbootclasspath:/usr/lib/jvm/java-6-openjdk/jre/lib/rt.jar"
-fi
+# See http://github.com/tlrobinson/narwhal\
+# /issuesearch?state=open&q=openjdk#issue/61/comment/289520
+# for further explanation
+#
+#if [ $isOpenJDK -gt 0 ]; then
+#    JAVA_OPTS="-Xbootclasspath:/usr/lib/jvm/java-6-openjdk/jre/lib/rt.jar"
+#fi
 
 if [ -n "$NARWHAL_CLASSPATH" ]; then
     CLASSPATH=$NARWHAL_CLASSPATH:$CLASSPATH


### PR DESCRIPTION
See http://github.com/tlrobinson/narwhal/issuesearch?state=open&q=openjdk#issue/61 which should be fixed for me. Which actual JVMs are currently still broken?
