### PR TITLE
A fix for Cappuccino issue 759.

### DIFF
--- a/engines/rhino/bin/narwhal-rhino
+++ b/engines/rhino/bin/narwhal-rhino
@@ -45,8 +45,6 @@ fi
 JAVA_OPTS="-Dhttp.proxyHost=$host -Dhttp.proxyPort=$port"
 JAVA_OPTS="$JAVA_OPTS -Dhttp.proxyUser=$username -Dhttp.proxyPassword=$password"
 
-echo $JAVA_OPTS
-
 if [ -n "$NARWHAL_CLASSPATH" ]; then
     CLASSPATH=$NARWHAL_CLASSPATH:$CLASSPATH
 fi

--- a/engines/rhino/bin/narwhal-rhino
+++ b/engines/rhino/bin/narwhal-rhino
@@ -21,7 +21,15 @@ fi
 
 CLASSPATH=$NARWHAL_ENGINE_HOME/jars/jna.jar
 BOOTCLASSPATH=$NARWHAL_ENGINE_HOME/jars/js.jar
-JAVA_OPTS=""
+
+# Parse the http_proxy environment variable.
+# http://cache.myproxy.com:42/ => cache.myproxy.com
+http_proxy_host=`echo $http_proxy | sed 's/http:\/\/\(.*\):.*/\1/'`
+
+# http://cache.myproxy.com:42/ =>  42
+http_proxy_port=`echo $http_proxy | sed 's/http:\/\/.*:\(.*\)\//\1/'`
+
+JAVA_OPTS="-Dhttp.proxyHost=$http_proxy_host -Dhttp.proxyPort=$http_proxy_port"
 
 if [ -n "$NARWHAL_CLASSPATH" ]; then
     CLASSPATH=$NARWHAL_CLASSPATH:$CLASSPATH

--- a/engines/rhino/bin/narwhal-rhino
+++ b/engines/rhino/bin/narwhal-rhino
@@ -22,14 +22,30 @@ fi
 CLASSPATH=$NARWHAL_ENGINE_HOME/jars/jna.jar
 BOOTCLASSPATH=$NARWHAL_ENGINE_HOME/jars/js.jar
 
-# Parse the http_proxy environment variable.
-# http://cache.myproxy.com:42/ => cache.myproxy.com
-http_proxy_host=`echo $http_proxy | sed 's/http:\/\/\(.*\):.*/\1/'`
+#Thanks, Glenn Jackman.
+#stackoverflow.com/questions/1199613/
+username=$(echo $http_proxy | ruby -ruri -e 'puts URI.parse(gets.chomp).user')
+password=$(echo $http_proxy | ruby -ruri -e 'puts URI.parse(gets.chomp).password')
+port=$(echo $http_proxy | ruby -ruri -e 'puts URI.parse(gets.chomp).port')
+host=$(echo $http_proxy | ruby -ruri -e 'puts URI.parse(gets.chomp).host')
 
-# http://cache.myproxy.com:42/ =>  42
-http_proxy_port=`echo $http_proxy | sed 's/http:\/\/.*:\(.*\)\//\1/'`
+if [ "$username" == "nil" ]; then
+  username=
+fi
+if [ $password == "nil" ]; then
+  password=
+fi
+if [ $host == "nil" ]; then
+  host=
+fi
+if [ $port == "nil" ]; then
+  port=
+fi
 
-JAVA_OPTS="-Dhttp.proxyHost=$http_proxy_host -Dhttp.proxyPort=$http_proxy_port"
+JAVA_OPTS="-Dhttp.proxyHost=$host -Dhttp.proxyPort=$port"
+JAVA_OPTS="$JAVA_OPTS -Dhttp.proxyUser=$username -Dhttp.proxyPassword=$password"
+
+echo $JAVA_OPTS
 
 if [ -n "$NARWHAL_CLASSPATH" ]; then
     CLASSPATH=$NARWHAL_CLASSPATH:$CLASSPATH

--- a/engines/rhino/lib/http-client-engine.js
+++ b/engines/rhino/lib/http-client-engine.js
@@ -9,14 +9,36 @@ var IO = require("io").IO;
 exports.open = function(url, mode, options) {
     var connection, output, input;
 
+    function setAuthenticator () {
+        var username = java.lang.System.getProperty("http.proxyUsername");
+        var password = java.lang.System.getProperty("http.proxyPassword");
+
+        if(username == null || password == null) {
+          return;
+        }
+
+	java.net.Authenticator.setDefault(
+          new Authenticator( 
+            { 'getPasswordAuthentication' : 
+               function() {
+	            return new PasswordAuthentication(username, 
+                                                      password.toCharArray())
+	       }
+  	    })
+        );
+
+    }
+
     function findProxy() {
+        setAuthenticator();
         selector = java.net.ProxySelector.getDefault();
         proxies = selector.select(java.net.URI(url));
+        print(url);
 
         //This list is never empty -- at the very least, it contains
         //java.net.Proxy.NO_PROXY.  See java.net.ProxySelector.select()
         //and java.net.Proxy.
-        return proxies.get(0);
+	return proxies.get(0);
     }
 
     function initConnection() {

--- a/engines/rhino/lib/http-client-engine.js
+++ b/engines/rhino/lib/http-client-engine.js
@@ -9,8 +9,19 @@ var IO = require("io").IO;
 exports.open = function(url, mode, options) {
     var connection, output, input;
 
+    function findProxy() {
+        selector = java.net.ProxySelector.getDefault();
+        proxies = selector.select(java.net.URI(url));
+
+        //This list is never empty -- at the very least, it contains
+        //java.net.Proxy.NO_PROXY.  See java.net.ProxySelector.select()
+        //and java.net.Proxy.
+        return proxies.get(0);
+    }
+
     function initConnection() {
-        connection = new java.net.URL(url).openConnection();
+        proxy = findProxy();
+        connection = new java.net.URL(url).openConnection(proxy);
         connection.setDoInput(true);
         connection.setDoOutput(false);
         connection.setRequestMethod(options.method);


### PR DESCRIPTION
Hi All,
   I have a fix that enables tusk to use the http_proxy environment variable.
Relevant: http://groups.google.com/group/narwhaljs/browse_thread/thread/33cd58b80db5b7a8/a7c95963b272f117

   Before this fix, the JVM would always assume that no proxy was needed for internet connectivity (unless configured otherwise).  Now, the http proxy hostname and port are supplied as arguments for java in the narwhal-rhino script.  This information is now utilized in the http-client-engine.

   The change was very small.

   Also, I noticed that a CLA is required for cappuccino -- is it also required for narwhal?  If so, let me know and I will take care of that.  

Thank you,
Daniel Phelps
