### PR TITLE
Use non-default JVM 

### DIFF
--- a/bin/narwhal
+++ b/bin/narwhal
@@ -26,6 +26,11 @@ if [ -f "narwhal.local.conf" ]; then
     source "narwhal.local.conf"
 fi
 
+# if JAVA_HOME is set, prepend JAVA_HOME/bin to PATH so correct JVM is used
+if [ -d "$JAVA_HOME" ]; then
+    export PATH=$JAVA_HOME/bin:$PATH
+fi
+
 if [ -n "$NARWHAL_DEBUG" ]; then
     export NARWHAL_DEBUG
 fi


### PR DESCRIPTION
Patch to allow the user to specifiy the JVM to use by setting the environment variable JAVA_HOME. I needed to use this on RHEL/CentOS 5, where Narwhal fails with the default JVM, but would work with optionally installed non-default JVMs.

This is done by prepending JAVA_HOME/bin to the PATH so that calls to the command 'java' use JAVA_HOME/bin/java instead the java in the system default location (usually /usr/bin/java).
