### PR TITLE
Fix bug with latest Mac OS JSC

### DIFF
--- a/packages/narwhal-lib/lib/narwhal/packages.js
+++ b/packages/narwhal-lib/lib/narwhal/packages.js
@@ -549,7 +549,7 @@ exports.updateUsingCatalog = function(options, usingCatalog, path, id, packageDa
             usingCatalog[id]["packages"][pair[0]] = exports.normalizePackageDescriptor(pair[1]);
         });
     }
-    if(UTIL.has(options, "includeBuildDependencies") &&
+    if(options && UTIL.has(options, "includeBuildDependencies") &&
        options.includeBuildDependencies &&
        UTIL.has(packageDatum, "build") &&
        UTIL.has(packageDatum.build, "using")) {


### PR DESCRIPTION
Hi,

With latest version of Mac OS (10.7.2 beta build 11C55), it seems there is problem with:

``` javascript
UTIL.has(options, "includeBuildDependencies")
```

it fails if `options` is undefined. This patch simply add a check on options. It seems to works smooth now
